### PR TITLE
ht16k33_alpha: Continuous scrolling and a custom buffer

### DIFF
--- a/components/ht16k33_alpha/README.md
+++ b/components/ht16k33_alpha/README.md
@@ -20,10 +20,14 @@ display:
     scroll_speed: 250ms
     scroll_dwell: 2s
     scroll_delay: 3
+    c_scroll: false
+    c_scroll_display_length: 4
+    c_scroll_spacer: "-."
     lambda: |-
       it.print("ABCD");
     secondary_displays:
       - address: 0x71
+    custom_buffer: 64
 ```
 
 # Optional parameters
@@ -36,5 +40,12 @@ display:
 
 `scroll_delay:` is the number (float, minimum 1) of `scroll_speed` cycles to wait at the beginning before starting to scroll, default 3
 
+`c_scroll:` "continuous scrolling", default to false
+
+`c_scroll_display_length:` is the amount of characters the display is able to show at once, default 4 (only needed if `c_scroll:` is enabled)
+
+`c_scroll_spacer:` is the text displayed between the end and the beginning of the continuous scroll, default "-." (only needed if `c_scroll:` is enabled)
+
 `secondary_display:` is a list of i2c devices where `address:` is required and `i2c_id:` is optional unless there is more than one i2c bus.
 
+`custom_buffer:` is a custom buffer size (how large the "text to display" is able to be), default 64

--- a/components/ht16k33_alpha/display.py
+++ b/components/ht16k33_alpha/display.py
@@ -9,10 +9,14 @@ ht16k33_alpha_ns = cg.esphome_ns.namespace('ht16k33_alpha')
 HT16K33AlphaDisplay = ht16k33_alpha_ns.class_('HT16K33AlphaDisplay', cg.PollingComponent, i2c.I2CDevice)
 
 CONF_SCROLL = "scroll"
+CONF_C_SCROLL = "c_scroll"
+CONF_C_SCROLL_DISPLAY_LENGTH = "c_scroll_display_length"
+CONF_C_SCROLL_SPACER = "c_scroll_spacer"
 CONF_SCROLL_SPEED = "scroll_speed"
 CONF_SCROLL_DWELL = "scroll_dwell"
 CONF_SCROLL_DELAY = "scroll_delay"
 CONF_SECONDARY_DISPLAYS = "secondary_displays"
+CONF_CUSTOM_BUFFER = "custom_buffer"
 
 CONFIG_SECONDARY = cv.Schema({
     cv.GenerateID(): cv.declare_id(i2c.I2CDevice)
@@ -21,10 +25,14 @@ CONFIG_SECONDARY = cv.Schema({
 CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(HT16K33AlphaDisplay),
     cv.Optional(CONF_SCROLL, default=False): cv.boolean,
+    cv.Optional(CONF_C_SCROLL, default=False): cv.boolean,
+    cv.Optional(CONF_C_SCROLL_DISPLAY_LENGTH, default='4'): cv.int_range(min=1),
+    cv.Optional(CONF_C_SCROLL_SPACER, default='-.'): cv.string,
     cv.Optional(CONF_SCROLL_SPEED, default='250ms'): cv.positive_time_period_milliseconds,
     cv.Optional(CONF_SCROLL_DWELL, default='2s'): cv.positive_time_period_milliseconds,
     cv.Optional(CONF_SCROLL_DELAY, default='3'): cv.float_range(min=1),
     cv.Optional(CONF_SECONDARY_DISPLAYS): cv.ensure_list(CONFIG_SECONDARY),
+    cv.Optional(CONF_CUSTOM_BUFFER, default='64'): cv.int_range(min=1, max=256),
 }).extend(cv.polling_component_schema('1s')).extend(i2c.i2c_device_schema(0x70))
 
 async def to_code(config):
@@ -40,6 +48,9 @@ async def to_code(config):
         cg.add(var.set_writer(lambda_))
     if config[CONF_SCROLL]:
         cg.add(var.set_scroll(True))
+        cg.add(var.set_c_scroll(config[CONF_C_SCROLL]))
+        cg.add(var.set_c_scroll_display_length(config[CONF_C_SCROLL_DISPLAY_LENGTH]))
+        cg.add(var.set_c_scroll_spacer(config[CONF_C_SCROLL_SPACER]))
         cg.add(var.set_scroll_speed(config[CONF_SCROLL_SPEED]))
         cg.add(var.set_scroll_dwell(config[CONF_SCROLL_DWELL]))
         cg.add(var.set_scroll_delay(int(config[CONF_SCROLL_DELAY] * config[CONF_SCROLL_SPEED].total_milliseconds)))
@@ -48,4 +59,5 @@ async def to_code(config):
             disp = cg.new_Pvariable(conf[CONF_ID])
             await i2c.register_i2c_device(disp, conf)
             cg.add(var.add_secondary_display(disp))
-
+    if CONF_CUSTOM_BUFFER in config:
+        cg.add(var.set_custom_buffer(config[CONF_CUSTOM_BUFFER]))

--- a/components/ht16k33_alpha/ht16k33_display.h
+++ b/components/ht16k33_alpha/ht16k33_display.h
@@ -19,9 +19,13 @@ class HT16K33AlphaDisplay : public PollingComponent, public i2c::I2CDevice {
   float get_setup_priority() const override;
   void add_secondary_display(i2c::I2CDevice *display) { this->displays_.push_back(display); }
   void set_scroll(bool scroll) { this->scroll_ = scroll; }
+  void set_c_scroll(bool c_scroll) { this->c_scroll_ = c_scroll; } // continuous scrolling
+  void set_c_scroll_display_length(unsigned long c_scroll_display_length) { this->c_scroll_display_length_ = c_scroll_display_length; } // display length for continuous scrolling
+  void set_c_scroll_spacer(std::string c_scroll_spacer) { this->c_scroll_spacer_ = c_scroll_spacer; } // spacer between the end and the beginning of the continuous scroll
   void set_scroll_speed(unsigned long scroll_speed) { this->scroll_speed_ = scroll_speed; }
   void set_scroll_dwell(unsigned long scroll_dwell) { this->scroll_dwell_ = scroll_dwell; }
   void set_scroll_delay(unsigned long scroll_delay) { this->scroll_delay_ = scroll_delay; }
+  void set_custom_buffer(unsigned long custom_buffer) { this->custom_buffer_ = custom_buffer; }  // custom buffer if needed
   void update() override;
   //// Clear display
   void set_brightness(float level);
@@ -47,11 +51,15 @@ class HT16K33AlphaDisplay : public PollingComponent, public i2c::I2CDevice {
   std::vector<i2c::I2CDevice *> displays_ {this};
   std::function<void(HT16K33AlphaDisplay &)> writer_;
   bool scroll_ {false};
+  bool c_scroll_ {false};
+  unsigned long c_scroll_display_length_ {4};
+  std::string c_scroll_spacer_ {"-."};
   unsigned long scroll_speed_ {250};
   unsigned long scroll_dwell_ {2000};
   unsigned long scroll_delay_ {750};
   unsigned long last_scroll_ {0};
-  uint8_t buffer_[64];
+  int custom_buffer_ {64};
+  uint8_t buffer_[256];
   int buffer_fill_ {0};
   int offset_ {0};
   uint8_t brightness_ = 16;


### PR DESCRIPTION
I've tried to add a option for continuous scrolling and a custom buffer size - it works fine for me (I'm not as experienced in programming as some others so if i did something that's not good, please tell me)

c_scroll (bool) = Enable/Disable continuous scrolling (scroll must be enabled) (def=false)

c_scroll_display_length (int) = the amount of characters the display is able to show at once (def=4)

c_scroll_spacer (string) = the string displayed between the end and the beginning of the continuous scroll (def="-.")

custom_buffer (int) = custom buffer size (def=64,max=256)