### PR TITLE
Add note about merged components

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ external_components:
     components: [ keypad ]
 ```
 
+## NOTE: Some components were merged to esphome :tada:
+- [keypad](https://github.com/ssieb/custom_components/tree/master/components/keypad) -> [matrix_keypad](https://esphome.io/components/matrix_keypad.html?highlight=keypad)


### PR DESCRIPTION
Hi!

I've been a happy user of your keypad component, and recently came to an error:

```
Failed config

external_components: [source wallmnt.yaml:42]
  - source: 
      type: git
      url: https://github.com/ssieb/custom_components
    components: 
      
      Could not find __init__.py file for component keypad. Please check the component is defined by this source (search path: .esphome/external_components/d2e825de/components/keypad/__init__.py).
      - keypad
```

I read esphome changelogs so luckly i knew that you merged that (congrats :tada:) - i think it would be nice to have a small note for future people like me