### PR TITLE
Reduce latency in full-duplex scenarios

### DIFF
--- a/components/uart_mitm/uart_mitm.cpp
+++ b/components/uart_mitm/uart_mitm.cpp
@@ -8,13 +8,15 @@ static const char *const TAG = "uart_mitm";
 
 void UARTMITM::loop() {
   uint8_t c;
-  while (this->uart1_->available()) {
-    this->uart1_->read_byte(&c);
-    this->uart2_->write_byte(c);
-  }
-  while (this->uart2_->available()) {
-    this->uart2_->read_byte(&c);
-    this->uart1_->write_byte(c);
+  while (this->uart1_->available() || this->uart2_->available()) {
+    if (this->uart1_->available()) {
+      this->uart1_->read_byte(&c);
+      this->uart2_->write_byte(c);
+    }
+    if (this->uart2_->available()) {
+      this->uart2_->read_byte(&c);
+      this->uart1_->write_byte(c);
+    }
   }
 }
 


### PR DESCRIPTION
It's a subtle difference, but it reduces per-character latency for a full duplex stream. Otherwise one direction is held up while the other direction is busy.