### PR TITLE
[DRAFT] Add [pin] option for [sensor.seesaw] and type: encoder

### DIFF
--- a/components/seesaw/__init__.py
+++ b/components/seesaw/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_INPUT,
     CONF_INVERTED,
     CONF_NUMBER,
+    CONF_PIN,
     CONF_MODE,
     CONF_OUTPUT,
     CONF_PULLUP,
@@ -49,6 +50,7 @@ SEESAW_PIN_SCHEMA = cv.All(
         cv.Required(CONF_NUMBER): cv.int_range(min=0, max=15),
         cv.Optional(CONF_MODE, default={}): cv.All(
             {
+                cv.Optional(CONF_PIN): cv.int_,
                 cv.Optional(CONF_INPUT, default=False): cv.boolean,
                 cv.Optional(CONF_PULLUP, default=False): cv.boolean,
                 cv.Optional(CONF_OUTPUT, default=False): cv.boolean,

--- a/components/seesaw/sensor/__init__.py
+++ b/components/seesaw/sensor/__init__.py
@@ -51,6 +51,7 @@ CONFIG_SCHEMA = cv.typed_schema(
         ).extend(
             {
                 cv.GenerateID(CONF_SEESAW): cv.use_id(Seesaw),
+                cv.Optional(CONF_PIN): cv.int_,
                 cv.Optional(CONF_NUMBER, default=0): cv.int_,
                 cv.Optional(CONF_MIN_VALUE): cv.int_,
                 cv.Optional(CONF_MAX_VALUE): cv.int_,

--- a/components/seesaw/sensor/__init__.py
+++ b/components/seesaw/sensor/__init__.py
@@ -94,7 +94,7 @@ async def to_code(config):
     elif config[CONF_TYPE] == CONF_ENCODER:
         cg.add(var.set_number(config[CONF_NUMBER]))
         if CONF_PIN in config:
-            cg.add(var.set_min_value(config[CONF_PIN]))
+            cg.add(var.set_pin(config[CONF_PIN]))
         if CONF_MIN_VALUE in config:
             cg.add(var.set_min_value(config[CONF_MIN_VALUE]))
         if CONF_MAX_VALUE in config:

--- a/components/seesaw/sensor/__init__.py
+++ b/components/seesaw/sensor/__init__.py
@@ -92,8 +92,9 @@ async def to_code(config):
     if config[CONF_TYPE] == CONF_ADC:
         cg.add(var.set_pin(config[CONF_PIN]))
     elif config[CONF_TYPE] == CONF_ENCODER:
-        cg.add(var.set_pin(config[CONF_PIN]))
         cg.add(var.set_number(config[CONF_NUMBER]))
+        if CONF_PIN in config:
+            cg.add(var.set_min_value(config[CONF_PIN]))
         if CONF_MIN_VALUE in config:
             cg.add(var.set_min_value(config[CONF_MIN_VALUE]))
         if CONF_MAX_VALUE in config:

--- a/components/seesaw/sensor/__init__.py
+++ b/components/seesaw/sensor/__init__.py
@@ -91,6 +91,7 @@ async def to_code(config):
     if config[CONF_TYPE] == CONF_ADC:
         cg.add(var.set_pin(config[CONF_PIN]))
     elif config[CONF_TYPE] == CONF_ENCODER:
+        cg.add(var.set_pin(config[CONF_PIN]))
         cg.add(var.set_number(config[CONF_NUMBER]))
         if CONF_MIN_VALUE in config:
             cg.add(var.set_min_value(config[CONF_MIN_VALUE]))

--- a/components/seesaw/sensor/seesawrotaryencoder.cpp
+++ b/components/seesaw/sensor/seesawrotaryencoder.cpp
@@ -7,7 +7,7 @@ namespace seesaw {
 static const char *const TAG = "seesaw.encoder";
 
 void SeesawRotaryEncoder::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up Seesaw rotary encoder...");
+  ESP_LOGCONFIG(TAG, "Setting up Seesaw rotary encoder %d ...", this->number_);
   this->parent_->enable_encoder(this->number_);
   this->publish_state(0);
 }

--- a/components/seesaw/sensor/seesawrotaryencoder.cpp
+++ b/components/seesaw/sensor/seesawrotaryencoder.cpp
@@ -12,6 +12,11 @@ void SeesawRotaryEncoder::setup() {
   this->publish_state(0);
 }
 
+void SeesawBinarySensor::dump_config() {
+  LOG_BINARY_SENSOR("", "Seesaw Encoder Sensor", this);
+  ESP_LOGCONFIG(TAG, "  Pin: %d", this->pin_);
+}
+
 void SeesawRotaryEncoder::loop() {
   int32_t new_value = this->parent_->get_encoder_position(this->number_);
   if (new_value < this->min_value_)

--- a/components/seesaw/sensor/seesawrotaryencoder.cpp
+++ b/components/seesaw/sensor/seesawrotaryencoder.cpp
@@ -12,7 +12,7 @@ void SeesawRotaryEncoder::setup() {
   this->publish_state(0);
 }
 
-void SeesawBinarySensor::dump_config() {
+void SeesawRotaryEncoder::dump_config() {
   ESP_LOGCONFIG("", "Seesaw Encoder Sensor", this);
   ESP_LOGCONFIG(TAG, "  Pin: %d", this->pin_);
 }

--- a/components/seesaw/sensor/seesawrotaryencoder.cpp
+++ b/components/seesaw/sensor/seesawrotaryencoder.cpp
@@ -13,7 +13,7 @@ void SeesawRotaryEncoder::setup() {
 }
 
 void SeesawBinarySensor::dump_config() {
-  LOG_BINARY_SENSOR("", "Seesaw Encoder Sensor", this);
+  ESP_LOGCONFIG("", "Seesaw Encoder Sensor", this);
   ESP_LOGCONFIG(TAG, "  Pin: %d", this->pin_);
 }
 

--- a/components/seesaw/sensor/seesawrotaryencoder.h
+++ b/components/seesaw/sensor/seesawrotaryencoder.h
@@ -20,6 +20,7 @@ class SeesawRotaryEncoder : public sensor::Sensor, public Component {
 
  protected:
   Seesaw *parent_;
+  int pin_;
   uint8_t number_{0};
   int32_t value_{0};
   int32_t min_value_{INT32_MIN};

--- a/components/seesaw/sensor/seesawrotaryencoder.h
+++ b/components/seesaw/sensor/seesawrotaryencoder.h
@@ -10,6 +10,7 @@ namespace seesaw {
 class SeesawRotaryEncoder : public sensor::Sensor, public Component {
  public:
   void setup() override;
+  void dump_config() override;
   void loop() override;
 
   void set_parent(Seesaw *parent) { parent_ = parent; }

--- a/components/seesaw/sensor/seesawrotaryencoder.h
+++ b/components/seesaw/sensor/seesawrotaryencoder.h
@@ -13,6 +13,7 @@ class SeesawRotaryEncoder : public sensor::Sensor, public Component {
   void loop() override;
 
   void set_parent(Seesaw *parent) { parent_ = parent; }
+  void set_pin(int pin) { this->pin_ = pin; }
   void set_number(uint8_t number) { number_ = number; }
   void set_min_value(int32_t min_value) { this->min_value_ = min_value; }
   void set_max_value(int32_t max_value) { this->max_value_ = max_value; }


### PR DESCRIPTION
[DRAFT] to add [pin] option for [sensor.seesaw] and type: encoder

These are the **pin names** in the seesaw firmware for each rotary encoder coming from : [Adafruit I2C Quad Rotary Encoder Breakout tutorial](https://learn.adafruit.com/adafruit-i2c-quad-rotary-encoder-breakout/circuitpython-and-python)

> The encoder A pin is towards the bottom of the board
> The encoder B pin is towards the top of the board

- Encoder 0
  -   Encoder A (anticlockwise):  pin 8
  -   Encoder B (clockwise):      pin 9
- Encoder 1
  -   Encoder A (anticlockwise):  pin 10
  -   Encoder B (clockwise):      pin 11
- Encoder 2
  -   Encoder A (anticlockwise):  pin 2
  -   Encoder B (clockwise):      pin 3
- Encoder 3
  -   Encoder A (anticlockwise):  pin 4
  -   Encoder B (clockwise):      pin 5

**Config**
```yaml
external_components:
  - source:
      type: git
      #url: https://github.com/ssieb/custom_components
      url: https://github.com/lboue/af_seesaw
      ref: set_pin
    refresh: 0s
    components: [ seesaw ]

i2c:
  sda: 26
  scl: 32
  scan: true
  id: bus_i2c

seesaw:

sensor:
    # https://github.com/lboue/af_seesaw/blob/set_pin/components/seesaw/sensor/__init__.py
  - platform: seesaw
    id: encoder0
    type: encoder
    number: 0
    pin: 8
    name: "Seesaw encoder #0"
    min_value: 0
    max_value: 255

  - platform: seesaw
    id: encoder1
    type: encoder
    number: 1
    pin: 10
    name: "Seesaw encoder #1"
    min_value: 0
    max_value: 255

  - platform: seesaw
    id: encoder2
    type: encoder
    number: 2
    pin: 2
    name: "Seesaw encoder #2"
    min_value: 0
    max_value: 255

  - platform: seesaw
    id: encoder3
    number: 3
    type: encoder
    pin: 4
    name: "Seesaw encoder #3"
    min_value: 0
    max_value: 255
```

**Regular boot log without pin specified**
```
[I][i2c.arduino:096]: Results from i2c bus scan:
[I][i2c.arduino:102]: Found i2c device at address 0x49
[C][seesaw:054]: Seesaw module:
[C][seesaw:055]:   Address: 0x49
[C][seesaw:058]:   CPU: ATtiny817
[C][seesaw:062]:   Version: 377019159
[C][seesaw:063]:   Options:
[C][seesaw:065]:     GPIO
[C][seesaw:067]:     Serial
[C][seesaw:069]:     Timer
[C][seesaw:071]:     ADC
[C][seesaw:075]:     Interrupt
[C][seesaw:077]:     DAP
[C][seesaw:081]:     NeoPixel
[C][seesaw:083]:     Touch
[C][seesaw.binary_sensor:017]: Seesaw Binary Sensor 'Seesaw encoder button #0'
[C][seesaw.binary_sensor:018]:   Pin: 12
[C][seesaw.binary_sensor:017]: Seesaw Binary Sensor 'Seesaw encoder button #1'
[C][seesaw.binary_sensor:018]:   Pin: 14
[C][seesaw.binary_sensor:017]: Seesaw Binary Sensor 'Seesaw encoder button #2'
[C][seesaw.binary_sensor:018]:   Pin: 17
[C][seesaw.binary_sensor:017]: Seesaw Binary Sensor 'Seesaw encoder button #3'
[C][seesaw.binary_sensor:018]:   Pin: 9
```

**Boot log with pin specified enabled**
```
[I][i2c.arduino:218]: Performing I2C bus recovery
[C][seesaw:035]: Setting up Seesaw...
[  1092][E][Wire.cpp:513] requestFrom(): i2cRead returned Error 263
[C][light:035]: Setting up light 'Seesaw neopixel'...
[D][light:036]: 'Seesaw neopixel' Setting:
[D][light:041]:   Color mode: RGB
[D][light:085]:   Transition length: 1.0s
[C][seesaw.encoder:010]: Setting up Seesaw rotary encoder 0 ...
[D][sensor:094]: 'Seesaw encoder 0': Sending state 0.00000 steps with 0 decimals of accuracy
[C][seesaw.encoder:010]: Setting up Seesaw rotary encoder 1 ...
[D][sensor:094]: 'Seesaw encoder 1': Sending state 0.00000 steps with 0 decimals of accuracy
[C][seesaw.encoder:010]: Setting up Seesaw rotary encoder 2 ...
[D][sensor:094]: 'Seesaw encoder 2': Sending state 0.00000 steps with 0 decimals of accuracy
[C][seesaw.encoder:010]: Setting up Seesaw rotary encoder 3 ...
[D][sensor:094]: 'Seesaw encoder 3': Sending state 0.00000 steps with 0 decimals of accuracy
...
[I][i2c.arduino:102]: Found i2c device at address 0x49
[C][seesaw:054]: Seesaw module:
[C][seesaw:055]:   Address: 0x49
[C][seesaw:058]:   CPU: ATtiny817
[C][seesaw:062]:   Version: 377019159
[C][seesaw:063]:   Options:
[C][seesaw:065]:     GPIO
[C][seesaw:067]:     Serial
[C][seesaw:069]:     Timer
[C][seesaw:071]:     ADC
[C][seesaw:075]:     Interrupt
[C][seesaw:077]:     DAP
[C][seesaw:081]:     NeoPixel
[C][seesaw:083]:     Touch
[C][:016]: Seesaw Encoder Sensor
[C][seesaw.encoder:017]:   Pin: 8
[C][:016]: Seesaw Encoder Sensor
[C][seesaw.encoder:017]:   Pin: 10
[C][:016]: Seesaw Encoder Sensor
[C][seesaw.encoder:017]:   Pin: 2
[C][:016]: Seesaw Encoder Sensor
[C][seesaw.encoder:017]:   Pin: 4
```
